### PR TITLE
Replicating Dims into Clickhouse

### DIFF
--- a/clickhouse/init/00_database.sql
+++ b/clickhouse/init/00_database.sql
@@ -1,1 +1,7 @@
+-- Allow MaterializedPostgreSQL (DB engine) for this session
+SET allow_experimental_database_materialized_postgresql = 1;
+
+-- (not strictly required here, but harmless if you later use the table engine)
+SET allow_experimental_materialized_postgresql_table = 1;
+
 CREATE DATABASE IF NOT EXISTS ctv;

--- a/clickhouse/init/00_database.sql
+++ b/clickhouse/init/00_database.sql
@@ -1,7 +1,1 @@
--- Allow MaterializedPostgreSQL (DB engine) for this session
-SET allow_experimental_database_materialized_postgresql = 1;
-
--- (not strictly required here, but harmless if you later use the table engine)
-SET allow_experimental_materialized_postgresql_table = 1;
-
 CREATE DATABASE IF NOT EXISTS ctv;

--- a/clickhouse/init/10_pg_replica.sql
+++ b/clickhouse/init/10_pg_replica.sql
@@ -1,0 +1,9 @@
+-- Must be in the same session as CREATE DATABASE
+SET allow_experimental_database_materialized_postgresql = 1;
+
+-- Create a database that continuously replicates specific PG tables
+CREATE DATABASE IF NOT EXISTS pg_ad
+ENGINE = MaterializedPostgreSQL('postgres:5432', 'ad_oltp', 'app', 'app')
+SETTINGS
+    materialized_postgresql_schema = 'public',                 -- one schema
+    materialized_postgresql_tables_list = 'advertisers,campaigns,creatives';

--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,12 @@ services:
       POSTGRES_DB: ad_oltp
       POSTGRES_USER: app
       POSTGRES_PASSWORD: app
+    command: >
+      postgres
+      -c wal_level=logical
+      -c max_replication_slots=8
+      -c max_wal_senders=8
+      -c max_worker_processes=16   
     volumes:
       - pg_data:/var/lib/postgresql/data
       #- ./postgres/init:/docker-entrypoint-initdb.d   # optional: init SQL
@@ -75,6 +81,7 @@ services:
     image: clickhouse/clickhouse-server:latest
     depends_on:
       clickhouse: { condition: service_healthy }
+      postgres: { condition: service_healthy }
     environment:
       - CLICKHOUSE_HOST=clickhouse
       - CLICKHOUSE_PORT=9000

--- a/postgres/init/01_dims.sql
+++ b/postgres/init/01_dims.sql
@@ -1,4 +1,4 @@
--- Basic Type-1 dims you’ll fill later via the Kotlin API
+-- DDL for basic Type-1 dims + utility triggers
 CREATE TABLE IF NOT EXISTS advertisers (
   advertiser_id SERIAL PRIMARY KEY,
   name         TEXT NOT NULL UNIQUE,
@@ -25,3 +25,36 @@ CREATE TABLE IF NOT EXISTS creatives (
   duration_ms     INT  NOT NULL,
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+-- Useful indexes for joins from creatives -> campaigns -> advertisers
+CREATE INDEX IF NOT EXISTS idx_campaigns_advertiser_id ON campaigns(advertiser_id);
+CREATE INDEX IF NOT EXISTS idx_creatives_campaign_id   ON creatives(campaign_id);
+
+-- Keep updated_at fresh
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END; $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_advertisers_updated_at') THEN
+    CREATE TRIGGER trg_advertisers_updated_at BEFORE UPDATE ON advertisers
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_campaigns_updated_at') THEN
+    CREATE TRIGGER trg_campaigns_updated_at BEFORE UPDATE ON campaigns
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_creatives_updated_at') THEN
+    CREATE TRIGGER trg_creatives_updated_at BEFORE UPDATE ON creatives
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+  END IF;
+END $$;
+
+-- (Optional) make sure the app user can create publications/slots (superuser in Docker, but harmless):
+ALTER ROLE app WITH REPLICATION;


### PR DESCRIPTION
# What was done?
- PostgreSQL
  - Updated dim tables with a trigger to update updated_at timestamp column on updates
  - In compose service definition, added wal & replica requirements as stated in https://clickhouse.com/docs/engines/database-engines/materialized-postgresql
- Clickhouse
  - Created ```pg_ad``` replica DB using MaterializedPostgreSQL engine
  - Clickhouse Init job depends on Postgres service healthy condition so that Replica setup can be done on tables that exist

# How was this Tested?
- Manually confirmed seed data accessible from clickhouse on replicated dims
- Manually conformed that replicated dims update (matter of <3 seconds) when Postgres table updated 
- Succesfully performed join between events table (fact table) and the replicated creatives table (dim table)

# New Deps?
- Experimental feature used in Clickhouse: MaterializedPostgreSQL